### PR TITLE
Fix for missing bold option in Sample app due explicit use of TextFontFace="OpenSansRegular"

### DIFF
--- a/samples/Indiko.Maui.Controls.Markdown.Sample/MainPage.xaml
+++ b/samples/Indiko.Maui.Controls.Markdown.Sample/MainPage.xaml
@@ -28,7 +28,7 @@
                           BlockQuoteBorderColor="{StaticResource Yellow100Accent}"
                           BlockQuoteFontFace="CamingoCodeItalic"
                           PlaceholderBackgroundColor="{StaticResource White}"
-                          TextFontFace="OpenSansRegular"
+                          TextFontFace="OpenSans"
                           TextFontSize="13"
                           TextColor="{StaticResource Black}"
                           HyperlinkColor="{StaticResource Blue100Accent}"


### PR DESCRIPTION
Removed direct reference to "OpenSansRegular" font face enabling use of bold, italic etc. variants of the font in the sample.

The sample markdown is now correctly shown with bold and italic (at least on iOS)