### PR TITLE
Remove the need for PlaceholderBackgroundColor and making sure no 

### DIFF
--- a/samples/Indiko.Maui.Controls.Markdown.Sample/MainPage.xaml
+++ b/samples/Indiko.Maui.Controls.Markdown.Sample/MainPage.xaml
@@ -5,6 +5,7 @@
              xmlns:idk="clr-namespace:Indiko.Maui.Controls.Markdown;assembly=Indiko.Maui.Controls.Markdown"
              x:Class="Indiko.Maui.Controls.Markdown.Sample.MainPage"
 			 x:DataType="vm:MainPageViewModel"
+             BackgroundColor="Beige"
              Title="Indiko.Maui.Controls.Markdown.Sample">
 
     <ScrollView>
@@ -27,7 +28,6 @@
                           BlockQuoteTextColor="{StaticResource Gray600}"
                           BlockQuoteBorderColor="{StaticResource Yellow100Accent}"
                           BlockQuoteFontFace="CamingoCodeItalic"
-                          PlaceholderBackgroundColor="{StaticResource White}"
                           TextFontFace="OpenSans"
                           TextFontSize="13"
                           TextColor="{StaticResource Black}"

--- a/src/Indiko.Maui.Controls.Markdown/MarkdownView.cs
+++ b/src/Indiko.Maui.Controls.Markdown/MarkdownView.cs
@@ -132,17 +132,6 @@ public class MarkdownView : ContentView
         set => SetValue(TextFontFaceProperty, value);
     }
 
-    /* ****** Spacer Block Styling ******** */
-
-    public static readonly BindableProperty PlaceholderBackgroundColorProperty =
-    BindableProperty.Create(nameof(PlaceholderBackgroundColor), typeof(Color), typeof(MarkdownView), Colors.White, propertyChanged: OnMarkdownTextChanged);
-
-    public Color PlaceholderBackgroundColor
-    {
-        get => (Color)GetValue(PlaceholderBackgroundColorProperty);
-        set => SetValue(PlaceholderBackgroundColorProperty, value);
-    }
-
     /* ****** Line Block Styling ******** */
 
     public static readonly BindableProperty LineColorProperty =
@@ -449,7 +438,8 @@ public class MarkdownView : ContentView
 
                 gridRow++;
 
-                AddEmptyRow(grid, ref gridRow);
+                // never finish with empty superfluous empty line
+                if (i != lines.Length - 1) AddEmptyRow(grid, ref gridRow);
             }
         }
 
@@ -546,10 +536,7 @@ public class MarkdownView : ContentView
     private void AddEmptyRow(Grid grid, ref int gridRow)
     {
         grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(10) });
-        var spacer = new BoxView { Color = PlaceholderBackgroundColor };
-        grid.Children.Add(spacer);
-        Grid.SetColumnSpan(spacer, 2);
-        Grid.SetRow(spacer, gridRow++);
+        gridRow++;
     }
 
     private static bool IsHorizontalRule(string line)


### PR DESCRIPTION
"superfluous" placeholder is added at the end

Hi,

I was struggling with the need to define the PlaceholderBackgroundColor and making sure the height of the MarkDownView had the correct height - when I hit me....

I removed the need for defining a PlaceholderBackgroundColor (**Breaking Change**) as defining a BoxView - with an active BackgroundColor is not needed.

Also made sure that no extra "Placeholder" is outputted in the end after everything else is rendered.

**Please note** to make the "fix" more apparent I've changed the background color of the sample plage to "beige".

Attached are some images 
![1 - Before Change 1 of 2](https://github.com/user-attachments/assets/66221582-50dd-4957-9406-4e11bf68287a)
![2 - Before Changes 2 of 2](https://github.com/user-attachments/assets/1244c869-7b3a-41e3-a293-ca515a0f6094)
![3 - After Changes 1 of 2](https://github.com/user-attachments/assets/adf1ca38-7964-4d3b-ba3b-f7f353ce81aa)
![4 - After Changes 2 of 2](https://github.com/user-attachments/assets/5d7d9499-836a-4c11-9c60-db08daf4bf05)

Best Regards,
Rene´


