### PR TITLE
Remove Microsoft.Maui.Controls.Compatibility

### DIFF
--- a/src/Indiko.Maui.Controls.Markdown/Indiko.Maui.Controls.Markdown.csproj
+++ b/src/Indiko.Maui.Controls.Markdown/Indiko.Maui.Controls.Markdown.csproj
@@ -40,7 +40,6 @@
 	  <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.8" />
 	  <PackageReference Include="SkiaSharp.Views.Maui.Core" Version="2.88.8" />
 	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.80" />
-	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.80" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
As I see in the [MarkdownView](https://github.com/0xc3u/Indiko.Maui.Controls.Markdown/blob/main/src/Indiko.Maui.Controls.Markdown/MarkdownView.cs) we don't need to use any `Compatibility` layout from Maui. This PR just removing that so for other users that don't use `Compatibility` layout can use it without adding the dependencies again